### PR TITLE
Make testAnyCustomerFromCity also accept `cooper`

### DIFF
--- a/Collections/All Any and other predicates/test/tests.kt
+++ b/Collections/All Any and other predicates/test/tests.kt
@@ -21,6 +21,6 @@ class TestAllAnyAndOtherPredicates {
 
     @Test(timeout = 1000)
     fun testAnyCustomerFromCity() {
-        Assert.assertTrue(errorMessage("findCustomerFrom"), customers[lucas] == shop.findCustomerFrom(Canberra))
+        Assert.assertTrue(errorMessage("findCustomerFrom"), setOf(customers[lucas], customer[cooper]).contains(shop.findCustomerFrom(Canberra)))
     }
 }


### PR DESCRIPTION
The test should pass if `findCustomerFrom` returns a customer from `Canberra`. Those are `lucas` and `copper`,  but so far the test only accepted `lucas`. This change adds also `copper`.

This fixes https://github.com/Kotlin/kotlin-koans-edu/issues/42.